### PR TITLE
Preloading vars should not happen anymore

### DIFF
--- a/src/main/resources/com/xebialabs/xlrelease/ci/XLReleaseNotifier/config.jelly
+++ b/src/main/resources/com/xebialabs/xlrelease/ci/XLReleaseNotifier/config.jelly
@@ -14,7 +14,7 @@
         </f:entry>
 
      <f:entry title="${%Variables}" field="variables" >
-             <f:repeatable var="variable" field="variables" noAddButton="false" minimum="${descriptor.getNumberOfVariables(instance.credential, instance.template)}">
+             <f:repeatable var="variable" field="variables" noAddButton="false" minimum="0">
                  <table width="100%">
                      <f:entry title="${%Name}" field="propertyName" help="/plugin/xlrelease-plugin/help-variable-name.html">
                          <f:select/>


### PR DESCRIPTION
Variables in XLR can be non required now, so preloading the whole list with minimum is not needed.