### PR TITLE
REL-7049 Don't need to force java7 anymore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,8 +226,8 @@ release {
 }
 
 task checkJavaVersion << {
-    if(JavaVersion.current() != JavaVersion.VERSION_1_7) {
-        throw new GradleException("This build must be run with java ${JavaVersion.VERSION_1_7}")
+    if(JavaVersion.current() < JavaVersion.VERSION_1_7) {
+        throw new GradleException("This build must be run with at least java ${JavaVersion.VERSION_1_7}")
     }
 }
 


### PR DESCRIPTION
- [x] XLR plugin keeps working on jenkins: `./gradlew server`

Should we update the dependencies to remove warnings?
```
warning: Supported source version 'RELEASE_6' from annotation processor 'jenkins.PluginSubtypeMarker' less than -source '1.8'
warning: No SupportedSourceVersion annotation found on org.kohsuke.wpc.ProcessorImpl, returning RELEASE_6.
warning: Supported source version 'RELEASE_6' from annotation processor 'org.kohsuke.wpc.ProcessorImpl' less than -source '1.8'
warning: Supported source version 'RELEASE_6' from annotation processor 'org.jvnet.hudson.annotation_indexer.AnnotationProcessorImpl' less than -source '1.8'
warning: Supported source version 'RELEASE_6' from annotation processor 'net.java.sezpoz.impl.Indexer6' less than -source '1.8'
warning: Supported source version 'RELEASE_6' from annotation processor 'org.kohsuke.stapler.jsr269.ConstructorProcessor' less than -source '1.8'
warning: Supported source version 'RELEASE_6' from annotation processor 'org.kohsuke.stapler.jsr269.ExportedBeanAnnotationProcessor' less than -source '1.8'
warning: Supported source version 'RELEASE_6' from annotation processor 'org.kohsuke.stapler.jsr269.QueryParameterAnnotationProcessor' less than -source '1.8'
warning: Supported source version 'RELEASE_6' from annotation processor 'org.kohsuke.stapler.jsr269.RequirePOSTAnnotationProcessor' less than -source '1.8'
warning: Supported source version 'RELEASE_6' from annotation processor 'org.kohsuke.stapler.jsr269.WebMethodAnnotationProcessor' less than -source '1.8'
```